### PR TITLE
Add PyTorchModelHubMixin to enable downloads on HF

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -2,12 +2,12 @@
 PyTorch Hub configuration for AnySat model.
 """
 
-import os
 import sys
-import torch
 import torch.nn as nn
 from pathlib import Path
 import warnings
+
+from huggingface_hub import PyTorchModelHubMixin
 
 REPO_ROOT = Path(__file__).parent
 if str(REPO_ROOT / "src") not in sys.path:
@@ -15,7 +15,8 @@ if str(REPO_ROOT / "src") not in sys.path:
 
 dependencies = ['torch']
 
-class AnySat(nn.Module):
+class AnySat(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/gastruc/AnySat", pipeline_tag="image-feature-extraction",
+             tags=["image-feature-extraction"], license="mit"):
     """
     AnySat: Earth Observation Model for Any Resolutions, Scales, and Modalities
     
@@ -79,29 +80,6 @@ class AnySat(nn.Module):
         
         if device is not None:
             self.model = self.model.to(device)
-    
-    @classmethod
-    def from_pretrained(cls, model_size='base', **kwargs):
-        """
-        Create a pretrained AnySat model
-        
-        Args:
-            model_size (str): Model size - 'tiny', 'small', or 'base'
-            **kwargs: Additional arguments passed to the constructor
-        """
-        model = cls(model_size=model_size, **kwargs)
-        
-        checkpoint_urls = {
-            'base': 'https://huggingface.co/g-astruc/AnySat/resolve/main/models/AnySat.pth',
-            # 'small': 'https://huggingface.co/gastruc/anysat/resolve/main/anysat_small_geoplex.pth', COMING SOON
-            # 'tiny': 'https://huggingface.co/gastruc/anysat/resolve/main/anysat_tiny_geoplex.pth' COMING SOON
-        }
-        
-        checkpoint_url = checkpoint_urls[model_size]
-        state_dict = torch.hub.load_state_dict_from_url(checkpoint_url, progress=True)['state_dict']
-        
-        model.model.load_state_dict(state_dict)
-        return model
     
     def forward(self, x, patch_size, output='patch', **kwargs):
         assert output in ['patch', 'tile', 'dense', 'all'], "Output must be one of 'patch', 'tile', 'dense', 'all'"


### PR DESCRIPTION
Hi @gastruc,

Thanks for this nice work and integrating with the hub already!

Fixes #1 

I wrote a quick PoC to showcase that makes HF integration even easier by leveraging the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to:
* track download numbers for your models (similar to models in the Transformers library)
* leverage safetensors for weights serialization
* add `from_pretrained` and `push_to_hub` automatically.

Usage is as follows:

```python
from hubconf import AnySat

# load model
model = AnySat(...)

# equip with weights
model.load_state_dict_from_url("https://huggingface.co/g-astruc/AnySat/blob/main/models/AnySat.pth")

# push to the hub
model.push_to_hub("nielsr/my-awesome-anysat-model")

# great! We can now use it as follows (+ this increments download numbers)
model = AnySat.from_pretrained("nielsr/anysat-demo")
```

Would you be interested in this integration?

Kind regards,

Niels